### PR TITLE
man: stop using legacy xorg m4 macros

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -24,11 +24,13 @@
 # from the copyright holders.
 #
 
-drivermandir = $(DRIVER_MAN_DIR)
+DRIVER_MAN_SUFFIX = 4
+
+drivermandir = $(mandir)/man$(DRIVER_MAN_SUFFIX)
 
 driverman_PRE = elographics.man
 
-driverman_DATA = $(driverman_PRE:man=@DRIVER_MAN_SUFFIX@)
+driverman_DATA = $(driverman_PRE:man=$(DRIVER_MAN_SUFFIX))
 
 EXTRA_DIST = elographics.man
 
@@ -36,6 +38,5 @@ CLEANFILES = $(driverman_DATA)
 
 SUFFIXES = .$(DRIVER_MAN_SUFFIX) .man
 
-# String replacements in MAN_SUBSTS now come from xorg-macros.m4 via configure
 .man.$(DRIVER_MAN_SUFFIX):
-	$(AM_V_GEN)$(SED) $(MAN_SUBSTS) < $< > $@
+	$(AM_V_GEN)$(SED) -e 's|__packagestring__|$(PACKAGE_STRING)|' < $< > $@

--- a/man/elographics.man
+++ b/man/elographics.man
@@ -1,6 +1,6 @@
 .\" shorthand for double quote that works everywhere.
 .ds q \N'34'
-.TH ELOGRAPHICS __drivermansuffix__ 2011-07-08 __vendorversion__
+.TH ELOGRAPHICS 4 2011-07-08 "__packagestring__" "X Version 11"
 .SH NAME
 elographics \- Elographics input driver for XLibre X server
 .SH SYNOPSIS
@@ -29,7 +29,7 @@ E281\-2310 and compatible devices are supported with some features
 unavailable.
 .SH "CONFIGURATION DETAILS"
 Please refer to
-.BR xorg.conf (__filemansuffix__)
+.BR xorg.conf (5)
 for general configuration details and
 for options that can be used with all input drivers.
 This section only covers configuration details specific to this driver.
@@ -83,10 +83,10 @@ The touchscreen model.
 Default: unset.
 Supported models: "Sunit dSeries".
 .SH "SEE ALSO"
-.BR XLibre (__appmansuffix__),
-.BR xorg.conf (__filemansuffix__),
-.BR Xserver (__appmansuffix__),
-.BR X (__miscmansuffix__).
+.BR XLibre (1),
+.BR xorg.conf (5),
+.BR Xserver (1),
+.BR X (7).
 .SH AUTHORS
 Authors include:
 Patrick Lecoanet


### PR DESCRIPTION
Make ourselves independent of old legacy xorg autoconf macros and ease later transition to meson.

This is a template for what should be done in all drivers step by step.